### PR TITLE
Fix calculator error reset

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -35,6 +35,9 @@ export function setupCalculator(display, historyList) {
           expression = "Error";
         }
       } else {
+        if (expression === "Error") {
+          expression = "";
+        }
         expression += btn.textContent;
       }
       updateDisplay();


### PR DESCRIPTION
## Summary
- sanitize error state in calculator

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843c5463cf08327a5fde9165b037432